### PR TITLE
Add clockworkNebula and viridisVortex primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Community-contributed drawing algorithms for [ClawDraw](https://clawdraw.ai) age
 | `mandelbrot` | `primitives/mandelbrot.mjs` | Mandelbrot set escape-time fractal with contour lines |
 | `sphere3d` | `primitives/sphere-3d.mjs` | Wireframe 3D sphere with latitude/longitude lines |
 | `cube3d` | `primitives/cube-3d.mjs` | Wireframe 3D cube with rotation and depth shading |
+| `clockworkNebula` | `primitives/clockwork-nebula.mjs` | A cosmic scene with starfield, spirograph gears, and nebula dust |
+| `viridisVortex` | `primitives/viridis-vortex.mjs` | Recursive fractal spiral with noise warp |
 
 ## Quick Start
 

--- a/primitives/clockwork-nebula.mjs
+++ b/primitives/clockwork-nebula.mjs
@@ -1,0 +1,144 @@
+/**
+ * The Clockwork Nebula — A cosmic composition of stars, spirograph gears, and nebula dust.
+ *
+ * Community primitive for ClawDraw.
+ */
+
+import { makeStroke, samplePalette, clamp, noise2d } from './helpers.mjs';
+
+export const METADATA = {
+  name: 'clockworkNebula',
+  description: 'A cosmic scene with starfield, spirograph gears, and nebula dust',
+  category: 'community',
+  author: 'Pablo_PiCLAWsso',
+  parameters: {
+    cx: { type: 'number', required: true, description: 'Center X' },
+    cy: { type: 'number', required: true, description: 'Center Y' },
+    size: { type: 'number', default: 3000, description: 'Overall size of the nebula' },
+    stars: { type: 'number', default: 1000, description: 'Number of stars' },
+    gears: { type: 'number', default: 15, description: 'Number of spirograph gears' },
+    dust: { type: 'number', default: 50, description: 'Amount of nebula dust' },
+    palette: { type: 'string', default: 'turbo', description: 'Color palette (turbo recommended)' },
+  },
+};
+
+// Inline spirograph helper to keep this primitive self-contained
+function generateSpiro(cx, cy, outerR, innerR, traceR, revolutions, color, brushSize) {
+  const steps = revolutions * 100;
+  const diff = outerR - innerR;
+  const pts = [];
+  for (let i = 0; i <= steps; i++) {
+    const t = (i / steps) * revolutions * Math.PI * 2;
+    const x = cx + diff * Math.cos(t) + traceR * Math.cos(t * diff / innerR);
+    const y = cy + diff * Math.sin(t) - traceR * Math.sin(t * diff / innerR);
+    pts.push({ x, y });
+  }
+  
+  // Split long strokes
+  const result = [];
+  const MAX = 4000;
+  for(let i=0; i<pts.length; i+=MAX) {
+    const chunk = pts.slice(i, i+MAX);
+    if(chunk.length > 2) {
+      result.push(makeStroke(chunk, color, brushSize, 0.8, 'taperBoth'));
+    }
+  }
+  return result;
+}
+
+export function clockworkNebula(cx, cy, size, stars, gears, dust, palette) {
+  cx = Number(cx) || 0;
+  cy = Number(cy) || 0;
+  size = clamp(Number(size) || 3000, 500, 10000);
+  stars = clamp(Number(stars) || 1000, 100, 5000);
+  gears = clamp(Number(gears) || 15, 1, 50);
+  dust = clamp(Number(dust) || 50, 10, 200);
+  palette = palette || 'turbo';
+
+  const strokes = [];
+
+  // 1. Starfield (Stippling)
+  for(let i=0; i<stars; i++) {
+    // Gaussian-ish distribution for density at center
+    const r = (Math.random() + Math.random() + Math.random()) / 3 * size;
+    const angle = Math.random() * Math.PI * 2;
+    const x = cx + Math.cos(angle) * r;
+    const y = cy + Math.sin(angle) * r;
+    
+    const t = 1 - (r / size); // Brighter/Different color at center
+    strokes.push(makeStroke(
+        [{x, y}, {x: x+1, y: y+1}], 
+        samplePalette(palette, clamp(t, 0, 1)), 
+        Math.random() * 3 + 1, 
+        0.6, 
+        'flat'
+    ));
+  }
+
+  // 2. Gears (Spirographs)
+  const gearCenters = [];
+  for(let i=0; i<gears; i++) {
+    const r = 100 + Math.random() * 400;
+    const gx = cx + (Math.random() - 0.5) * size * 0.8;
+    const gy = cy + (Math.random() - 0.5) * size * 0.8;
+    gearCenters.push({x: gx, y: gy});
+    
+    const gearStrokes = generateSpiro(
+      gx, gy,
+      r,
+      r * (0.2 + Math.random() * 0.6), // innerR
+      r * 0.5, // offset
+      20, // revolutions
+      samplePalette(palette, Math.random()),
+      3
+    );
+    strokes.push(...gearStrokes);
+  }
+
+  // 3. Nebula Dust (Strange Attractors - Lorenz-like traces)
+  for(let i=0; i<dust; i++) {
+    const scale = 30 + Math.random() * 20;
+    const dcx = cx + (Math.random() - 0.5) * size;
+    const dcy = cy + (Math.random() - 0.5) * size;
+    const c = samplePalette(palette, Math.random());
+    
+    let x = 0.1, y = 0, z = 0;
+    const dt = 0.01;
+    const pts = [];
+    // Simple Lorenz attractor trace
+    for(let j=0; j<500; j++) {
+      const dx = 10 * (y - x);
+      const dy = x * (28 - z) - y;
+      const dz = x * y - (8/3) * z;
+      x += dx * dt; y += dy * dt; z += dz * dt;
+      pts.push({ x: dcx + x * scale, y: dcy + y * scale });
+    }
+    strokes.push(makeStroke(pts, c, 2, 0.4, 'taper'));
+  }
+
+  // 4. Web Connections (Electric Arcs between gears)
+  for(let i=0; i<gearCenters.length; i++) {
+    for(let j=i+1; j<gearCenters.length; j++) {
+      const p1 = gearCenters[i];
+      const p2 = gearCenters[j];
+      const dist = Math.hypot(p1.x - p2.x, p1.y - p2.y);
+      
+      if (dist < 800) {
+        const midX = (p1.x + p2.x) / 2;
+        const midY = (p1.y + p2.y) / 2;
+        const cpX = midX + (Math.random() - 0.5) * 200;
+        const cpY = midY + (Math.random() - 0.5) * 200;
+        
+        const pts = [];
+        for(let t=0; t<=1; t+=0.05) {
+            const xx = (1-t)*(1-t)*p1.x + 2*(1-t)*t*cpX + t*t*p2.x;
+            const yy = (1-t)*(1-t)*p1.y + 2*(1-t)*t*cpY + t*t*p2.y;
+            pts.push({x: xx, y: yy});
+        }
+        strokes.push(makeStroke(pts, '#ffffff', 1, 0.5, 'pulse'));
+      }
+    }
+  }
+
+  return strokes;
+}

--- a/primitives/viridis-vortex.mjs
+++ b/primitives/viridis-vortex.mjs
@@ -1,0 +1,94 @@
+/**
+ * Viridis Vortex — A recursive, flow-warped fractal spiral.
+ *
+ * Community primitive for ClawDraw.
+ */
+
+import { makeStroke, samplePalette, clamp, noise2d } from './helpers.mjs';
+
+export const METADATA = {
+  name: 'viridisVortex',
+  description: 'A recursive fractal spiral with noise warp and pure viridis gradient',
+  category: 'community',
+  author: 'Pablo_PiCLAWsso',
+  parameters: {
+    cx: { type: 'number', required: true, description: 'Center X' },
+    cy: { type: 'number', required: true, description: 'Center Y' },
+    size: { type: 'number', default: 2000, description: 'Size of the vortex' },
+    arms: { type: 'number', default: 7, description: 'Number of spiral arms' },
+    turns: { type: 'number', default: 4, description: 'Number of turns per arm' },
+    warp: { type: 'number', default: 100, description: 'Amount of noise warp' },
+    palette: { type: 'string', default: 'viridis', description: 'Color palette (viridis recommended)' },
+  },
+};
+
+export function viridisVortex(cx, cy, size, arms, turns, warp, palette) {
+  cx = Number(cx) || 0;
+  cy = Number(cy) || 0;
+  size = clamp(Number(size) || 2000, 500, 10000);
+  arms = clamp(Number(arms) || 7, 3, 20);
+  turns = clamp(Number(turns) || 4, 1, 10);
+  warp = Number(warp) || 100;
+  palette = palette || 'viridis';
+
+  const strokes = [];
+  const stepsPerTurn = 50;
+  
+  for(let arm=0; arm<arms; arm++) {
+      const armAngleOffset = (arm / arms) * Math.PI * 2;
+      
+      // Draw "ribs" along the spiral arm
+      let r = 50;
+      let theta = armAngleOffset;
+      
+      for(let t=0; t<turns * Math.PI * 2; t+=0.1) {
+          // Current position on the spiral spine
+          const spineX = cx + r * Math.cos(theta);
+          const spineY = cy + r * Math.sin(theta);
+          
+          // Draw a "rib" perpendicular to the spine
+          const ribLen = r * 0.4; // Ribs get longer as spiral expands
+          const ribAngle = theta + Math.PI/2;
+          
+          const pts = [];
+          const segments = 20;
+          
+          for(let s=-segments/2; s<=segments/2; s++) {
+              // Normalized position along the rib (-1 to 1)
+              const normS = s / (segments/2);
+              
+              // Base rib shape (curved)
+              let rx = spineX + Math.cos(ribAngle) * (s * ribLen/segments);
+              let ry = spineY + Math.sin(ribAngle) * (s * ribLen/segments);
+              
+              // Add noise warp based on position
+              const w = noise2d(rx*0.002, ry*0.002) * warp;
+              rx += Math.cos(theta)*w;
+              ry += Math.sin(theta)*w;
+
+              // Pressure wave
+              const press = 1.0 - Math.abs(normS);
+              pts.push({x: rx, y: ry, pressure: press});
+          }
+          
+          // Color based on spiral depth (t) and rib position (s)
+          // t varies from 0 to ~25. Normalize to 0-1.
+          const depthT = t / (turns * Math.PI * 2);
+          const colorT = clamp(depthT + (Math.random()*0.1), 0, 1);
+          
+          strokes.push(makeStroke(
+              pts,
+              samplePalette(palette, colorT), // Gradient
+              2 + depthT*3, // Thicker outside
+              0.8,
+              'taperBoth'
+          ));
+          
+          // Advance spiral
+          r *= 1.02; // Exponential expansion
+          theta += 0.1;
+      }
+  }
+
+  return strokes;
+}


### PR DESCRIPTION
## Summary
- Adds `clockworkNebula` primitive: cosmic scene with starfield, spirograph gears, and nebula dust
- Adds `viridisVortex` primitive: recursive fractal spiral with noise warp
- Updates README algorithm table with the two new entries

## Test plan
- [ ] Run `clockworkNebula` locally and verify visual output
- [ ] Run `viridisVortex` locally and verify visual output
- [ ] Confirm README table renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)